### PR TITLE
Return value instead of echoing it in `admin_footer_text` callback

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -218,8 +218,10 @@ function instant_images_filter_admin_footer_text( $text ) {
 	if ( in_array( $screen->base, $base_array, true ) ) {
 		$divider = '<em>|</em>';
 		$love    = '<span style="color: #e25555;">♥</span>';
-		echo wp_kses_post( INSTANT_IMAGES_TITLE . ' is made with ' . $love . ' by <a href="https://connekthq.com/?utm_source=WPAdmin&utm_medium=InstantImages&utm_campaign=Footer" target="_blank" style="font-weight: 500;">Connekt</a> &rarr; <a href="https://getinstantimages.com/add-ons/extended/" target="_blank" style="font-weight: 500;">Get Extended</a> ' . $divider . ' <a href="https://wordpress.org/support/plugin/instant-images/reviews/#new-post" target="_blank" style="font-weight: 500;">Leave a Review</a> ' . $divider . ' <a href="https://getinstantimages.com/terms-of-use/" target="_blank" style="font-weight: 500;">Terms</a> ' . $divider . ' <a href="https://getinstantimages.com/privacy-policy/" target="_blank" style="font-weight: 500;">Privacy Policy</a>' );
+		$text = wp_kses_post( INSTANT_IMAGES_TITLE . ' is made with ' . $love . ' by <a href="https://connekthq.com/?utm_source=WPAdmin&utm_medium=InstantImages&utm_campaign=Footer" target="_blank" style="font-weight: 500;">Connekt</a> &rarr; <a href="https://getinstantimages.com/add-ons/extended/" target="_blank" style="font-weight: 500;">Get Extended</a> ' . $divider . ' <a href="https://wordpress.org/support/plugin/instant-images/reviews/#new-post" target="_blank" style="font-weight: 500;">Leave a Review</a> ' . $divider . ' <a href="https://getinstantimages.com/terms-of-use/" target="_blank" style="font-weight: 500;">Terms</a> ' . $divider . ' <a href="https://getinstantimages.com/privacy-policy/" target="_blank" style="font-weight: 500;">Privacy Policy</a>' );
 	}
+	
+	return $text;
 }
 add_filter( 'admin_footer_text', 'instant_images_filter_admin_footer_text' ); // Admin menu text.
 


### PR DESCRIPTION
Filter hook callbacks must `return` their value, and not directly `echo` it.

This otherwise creates problem for other plugins (like mine), as they then get passed `null` as the filter hook variable.